### PR TITLE
refactor: ParquetTag validation now ensures name is DuckDB compliant

### DIFF
--- a/schema/parquet_tag.go
+++ b/schema/parquet_tag.go
@@ -2,9 +2,10 @@ package schema
 
 import (
 	"fmt"
-	"golang.org/x/exp/maps"
-
+	"regexp"
 	"strings"
+
+	"golang.org/x/exp/maps"
 )
 
 // ParquetTag represents the components of a parquet tag
@@ -83,8 +84,89 @@ var validDuckDBTypes = map[string]struct{}{
 	"JSON":      {},
 }
 
+var reservedKeywords = map[string]struct{}{
+	"ALL":               {},
+	"ANALYZE":           {},
+	"AND":               {},
+	"AS":                {},
+	"ASC":               {},
+	"CASE":              {},
+	"CAST":              {},
+	"CHECK":             {},
+	"COLLATE":           {},
+	"COLUMN":            {},
+	"CONSTRAINT":        {},
+	"CREATE":            {},
+	"CROSS":             {},
+	"CURRENT_DATE":      {},
+	"CURRENT_TIME":      {},
+	"CURRENT_TIMESTAMP": {},
+	"DEFAULT":           {},
+	"DEFERRABLE":        {},
+	"DESC":              {},
+	"DISTINCT":          {},
+	"DO":                {},
+	"ELSE":              {},
+	"END":               {},
+	"EXCEPT":            {},
+	"FOR":               {},
+	"FOREIGN":           {},
+	"FROM":              {},
+	"FULL":              {},
+	"GLOB":              {},
+	"GROUP":             {},
+	"HAVING":            {},
+	"IN":                {},
+	"INITIALLY":         {},
+	"INNER":             {},
+	"INTERSECT":         {},
+	"INTO":              {},
+	"IS":                {},
+	"ISNULL":            {},
+	"JOIN":              {},
+	"LEFT":              {},
+	"LIKE":              {},
+	"LIMIT":             {},
+	"NATURAL":           {},
+	"NOT":               {},
+	"NOTNULL":           {},
+	"NULL":              {},
+	"OFFSET":            {},
+	"ON":                {},
+	"OR":                {},
+	"ORDER":             {},
+	"OUTER":             {},
+	"PRIMARY":           {},
+	"REFERENCES":        {},
+	"RIGHT":             {},
+	"SELECT":            {},
+	"TABLE":             {},
+	"THEN":              {},
+	"TO":                {},
+	"UNION":             {},
+	"UNIQUE":            {},
+	"USING":             {},
+	"WHEN":              {},
+	"WHERE":             {},
+	"WINDOW":            {},
+	"WITH":              {},
+}
+
 func (t *ParquetTag) validate() (*ParquetTag, error) {
-	// TODO #validation validate name is duckdb compliant? https://github.com/turbot/tailpipe-plugin-sdk/issues/70
+	quotedRegex := regexp.MustCompile(`^".*"$`)
+	unquotedRegex := regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9_]*$`)
+
+	// Quoted identifiers can use any keyword, whitespace or special character, e.g., "SELECT" and " § 🦆 ¶ " are valid identifiers. https://duckdb.org/docs/sql/dialect/keywords_and_identifiers.html#identifiers
+	if !quotedRegex.MatchString(t.Name) {
+		// Unquoted identifiers must start with a letter and can only contain letters, numbers, and underscores
+		if !unquotedRegex.MatchString(t.Name) {
+			return nil, fmt.Errorf("invalid parquet tag: 'name' must be a valid DuckDB identifier")
+		}
+		// Check if the name is a reserved keyword
+		if _, reserved := reservedKeywords[strings.ToUpper(t.Name)]; reserved {
+			return nil, fmt.Errorf("invalid parquet tag: 'name' cannot be a reserved keyword")
+		}
+	}
 
 	if t.Type != "" {
 		// Convert type to upper case for case-insensitive comparison


### PR DESCRIPTION
Closes #70 