### PR TITLE
NewConversionSchemaWithInferredSchema now includes all source columns…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/satyrius/gonx v1.4.0
 	github.com/stretchr/testify v1.10.0
 	github.com/turbot/go-kit v1.2.0
-	github.com/turbot/pipe-fittings/v2 v2.3.2-rc.1
+	github.com/turbot/pipe-fittings/v2 v2.3.2
 	github.com/zclconf/go-cty v1.14.4
 	golang.org/x/exp v0.0.0-20250128182459-e0ece0dbea4c
 	golang.org/x/sync v0.11.0

--- a/go.sum
+++ b/go.sum
@@ -701,8 +701,8 @@ github.com/tkrajina/go-reflector v0.5.8 h1:yPADHrwmUbMq4RGEyaOUpz2H90sRsETNVpjzo
 github.com/tkrajina/go-reflector v0.5.8/go.mod h1:ECbqLgccecY5kPmPmXg1MrHW585yMcDkVl6IvJe64T4=
 github.com/turbot/go-kit v1.2.0 h1:4pBDu2LGoqF2y6ypL4xJjqlDW0BkUw3IIDlyHkU0O88=
 github.com/turbot/go-kit v1.2.0/go.mod h1:1xmRuQ0cn/10QUMNLNOAFIqN8P6Rz5s3VLT8mkN3nF8=
-github.com/turbot/pipe-fittings/v2 v2.3.2-rc.1 h1:TeQgP9ImD3IQES+pQoD0mliZ/18F/FoQRci7neaAaJA=
-github.com/turbot/pipe-fittings/v2 v2.3.2-rc.1/go.mod h1:wEoN4EseMTXophNlpOe740rAC9Jg0JhGRt5QM5R2ss8=
+github.com/turbot/pipe-fittings/v2 v2.3.2 h1:MtLgTRJFjn+J7vMmwifyFpoaroAgMyWo0GHeEmJJ4So=
+github.com/turbot/pipe-fittings/v2 v2.3.2/go.mod h1:wEoN4EseMTXophNlpOe740rAC9Jg0JhGRt5QM5R2ss8=
 github.com/turbot/pipes-sdk-go v0.12.0 h1:esbbR7bALa5L8n/hqroMPaQSSo3gNM/4X0iTmHa3D6U=
 github.com/turbot/pipes-sdk-go v0.12.0/go.mod h1:Mb+KhvqqEdRbz/6TSZc2QWDrMa5BN3E4Xw+gPt2TRkc=
 github.com/turbot/terraform-components v0.0.0-20231213122222-1f3526cab7a7 h1:qDMxFVd8Zo0rIhnEBdCIbR+T6WgjwkxpFZMN8zZmmjg=

--- a/schema/conversion_schema.go
+++ b/schema/conversion_schema.go
@@ -1,5 +1,7 @@
 package schema
 
+import "golang.org/x/exp/maps"
+
 // SourceColumnDef is a simple struct to hold the column name and type for a source column
 type SourceColumnDef struct {
 	Name string
@@ -37,10 +39,7 @@ func NewConversionSchemaWithInferredSchema(tableSchema, inferredSchema *TableSch
 	}
 
 	// build a list of source columns - these are the columns to read from the JSONL
-	var sourceColumns []SourceColumnDef
-
-	//get the table schema as a map
-	schemaMap := r.AsMap()
+	var sourceColumns = map[string]SourceColumnDef{}
 
 	// First add the source column for all columns the table schema (unless there is transform)
 	for _, c := range tableSchema.Columns {
@@ -48,18 +47,18 @@ func NewConversionSchemaWithInferredSchema(tableSchema, inferredSchema *TableSch
 			// skip this column - it is a transform so the source column will not be used
 			continue
 		}
-		sourceColumns = append(sourceColumns, NewSourceColumnDef(c))
+		sourceColumns[c.SourceName] = NewSourceColumnDef(c)
 	}
 
 	// now populate the source columns from the inferred schema
 	for _, c := range inferredSchema.Columns {
-		// if this column exists in the table def, we have already added it to source columns so nothing to do
-		if _, haveColumn := schemaMap[c.ColumnName]; haveColumn {
+		// if we do not already have this column, add it
+		if _, haveColumn := sourceColumns[c.SourceName]; haveColumn {
 			continue
 		}
 
 		// add to source columns - we may use use any column for a transform
-		sourceColumns = append(sourceColumns, NewSourceColumnDef(c))
+		sourceColumns[c.SourceName] = NewSourceColumnDef(c)
 
 		// only add the inferred column to 'Columns' if it satisfies MapFields
 		// does this column match the any of the map fields?
@@ -69,7 +68,7 @@ func NewConversionSchemaWithInferredSchema(tableSchema, inferredSchema *TableSch
 	}
 
 	// now set the source columns
-	r.SourceColumns = sourceColumns
+	r.SourceColumns = maps.Values(sourceColumns)
 	return r
 }
 

--- a/types/dynamic_row.go
+++ b/types/dynamic_row.go
@@ -47,7 +47,7 @@ func (l *DynamicRow) Enrich(tableSchema *schema.TableSchema, sourceEnrichmentFie
 	for k, v := range sourceEnrichmentFields.CommonFields.AsMap() {
 		// if there a non empty value for this field, include it
 		if v != "" {
-			l.sourceColumns[k] = v
+			l.OutputColumns[k] = v
 		}
 	}
 


### PR DESCRIPTION
… even if same column name in output columns has a transform. (#176)

DynamicRow.Enrich adds sourceEnrichmentFields to output columns, not source columns