### PR TITLE
RowEnrichmentCollector.GetSchema should merge schema with common schema before returning. Closes #237

### DIFF
--- a/schema/schema_builder.go
+++ b/schema/schema_builder.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/iancoleman/strcase"
-	"golang.org/x/exp/maps"
 )
 
 const maxNesting = 10
@@ -43,9 +42,7 @@ func (b *SchemaBuilder) SchemaFromStruct(s any) (*TableSchema, error) {
 		// merge the default common field descriptions with column descriptions from the struct
 		// NOTE: the struct descriptions will overwrite the default descriptions - it may use this to override
 		// the descriptions for the common fields
-		columnDescriptions := DefaultCommonFieldDescriptions
-		maps.Copy(columnDescriptions, desc.GetColumnDescriptions())
-
+		columnDescriptions := desc.GetColumnDescriptions()
 		for _, c := range res.Columns {
 			if desc, ok := columnDescriptions[c.ColumnName]; ok {
 				c.Description = desc

--- a/table/row_enrichment_collector.go
+++ b/table/row_enrichment_collector.go
@@ -116,6 +116,8 @@ func (c *RowEnrichmentCollector[R]) GetSchema() (*schema.TableSchema, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error getting schema from struct: %w", err)
 	}
+	// merge this with the common fields schema
+	s = s.MergeWithCommonSchema()
 
 	// if the table implements DescriptionProvider, use this to populate the table description
 	if getDesc, ok := c.table.(schema.DescriptionProvider); ok {


### PR DESCRIPTION
SchemaFromStruct no longer merges common field descriptions