### PR TITLE
fix continuation

### DIFF
--- a/collection_state/artifact_collection_state_test.go
+++ b/collection_state/artifact_collection_state_test.go
@@ -31,6 +31,7 @@ func TestArtifactCollectionState_MigrateFromLegacyState(t *testing.T) {
 			}, timeString("2023-12-01 12:00:00")),
 			expected: buildArtifactCollectionState(map[string]*TimeRangeCollectionState{
 				"/trunk1": buildTimeRangeCollectionState(CollectionOrderChronological, time.Hour*24,
+
 					buildTimeRangeState("2023-10-01 00:00:00", "2023-12-01 01:00:00", time.Hour*24, CollectionOrderChronological),
 				),
 			}, time.Hour*24),
@@ -87,6 +88,7 @@ func buildArtifactCollectionStateLegacy(trunks map[string]*TimeRangeCollectionSt
 	}
 }
 
+// TODO update this to set end time on or after last entry time to me more realistic
 // buildTimeRangeCollectionStateLegacy constructs a legacy time range collection state for tests
 func buildTimeRangeCollectionStateLegacy(fromStr, toStr string, granularity time.Duration, order CollectionOrder, endObjects ...string) *TimeRangeCollectionStateLegacy {
 	from, err := time.Parse("2006-01-02 15:04:05", fromStr)

--- a/collection_state/time_range_collection_state.go
+++ b/collection_state/time_range_collection_state.go
@@ -341,13 +341,17 @@ func (t *TimeRangeCollectionState) addRangeFromLegacy(legacy *TimeRangeCollectio
 	var lowerBoundary, upperBoundary time.Time
 
 	lowerBoundary = legacy.FirstEntryTime
-	// on the legacy state, the EndTime is inclusive but now it is exclusive
-	//
-	// is end time is after last entry time use that
-	if legacy.EndTime.After(legacy.LastEntryTime) {
+	// if end time is on or after last entry time use that
+	// this is the normal case for a collection that has been completed successfully
+	if legacy.EndTime.Compare(legacy.LastEntryTime) >= 0 {
 		upperBoundary = legacy.EndTime
+		// for forward collection, convert upper boundary inclusive to exclusive (by adding the granularity)
+		// (unless there are end objects in which case the day is not complete)
+		if t.Order == CollectionOrderChronological && len(legacy.EndObjects) == 0 {
+			upperBoundary = upperBoundary.Add(t.Granularity)
+		}
 	} else {
-		// otherwise use LastEntryTime
+		// otherwise use LastEntryTime - for some reaons
 		upperBoundary = legacy.LastEntryTime
 	}
 

--- a/collection_state/time_range_collection_state.go
+++ b/collection_state/time_range_collection_state.go
@@ -347,6 +347,11 @@ func (t *TimeRangeCollectionState) addRangeFromLegacy(legacy *TimeRangeCollectio
 		upperBoundary = legacy.EndTime
 		// for forward collection, convert upper boundary inclusive to exclusive (by adding the granularity)
 		// (unless there are end objects in which case the day is not complete)
+		//
+		// this works around an issue in prev collection state where the end objects are cleared on collection complete,
+		// even if the day is not complete. This could lead to duplicate objects being collected once after migration.
+		//
+		// To avoid this, shift the collection end time forward by one granularity period
 		if t.Order == CollectionOrderChronological && len(legacy.EndObjects) == 0 {
 			upperBoundary = upperBoundary.Add(t.Granularity)
 		}


### PR DESCRIPTION
this works around an issue in prev collection state where the end objects are cleared on collection complete, 		even if the day is not complete. This could lead to duplicate objects being collected once after migration.

To avoid this, shift the collection end time forward by one granularity period