### PR TITLE
Do not clear end objects in TimeRangeCollectionState.OnCollectionComplete if granularity is zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.9.1 [2025-07-02]
+_Bug fixes_
+* Do not clear end objects in TimeRangeCollectionState.OnCollectionComplete if granularity is zero. Closes  ([#251](https://github.com/turbot/tailpipe-plugin-sdk/issues/251))
+* TimeRangeObjectState.Validate does not validate TimeRange if granularity is zero
+
 ## v0.9.0 [2025-07-02]
 _Whats new_
 

--- a/collection_state/time_range_collection_state.go
+++ b/collection_state/time_range_collection_state.go
@@ -150,6 +150,12 @@ func (t *TimeRangeCollectionState) OnCollectionComplete() error {
 	if t.currentCollectionTimeRange == nil {
 		return fmt.Errorf("cannot complete collection - no current collection set, Init must be called first")
 	}
+	// if we have no granularity we have nothing to do
+	if t.Granularity == 0 {
+		slog.Info("Granularity is zero - no collection complete action required")
+		return nil
+	}
+
 	// set the upper boundary time of the active range to the upper boundary time of the collection time range
 	t.activeRange.setUpperBoundaryTime(t.currentCollectionTimeRange.EndTime())
 

--- a/collection_state/time_range_object_state.go
+++ b/collection_state/time_range_object_state.go
@@ -145,6 +145,9 @@ func (s *TimeRangeObjectState) GetGranularity() time.Duration {
 }
 
 func (s *TimeRangeObjectState) Validate() error {
+	if s.Granularity == 0 {
+		return nil
+	}
 	return s.TimeRange.Validate()
 }
 


### PR DESCRIPTION
…

TimeRangeObjectState.Validate does not validate TimeRange if granularity is zero