### PR TITLE
Pin actions/setup-go to a full commit SHA

### DIFF
--- a/.github/workflows/10-test-lint.yaml
+++ b/.github/workflows/10-test-lint.yaml
@@ -31,7 +31,7 @@ jobs:
           path: tailpipe-plugin-sdk
 
       # this is required, check golangci-lint-action docs
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: '1.24'
           cache: false # setup-go v4 caches by default, do not change this parameter, check golangci-lint-action doc: https://github.com/golangci/golangci-lint-action/pull/704

--- a/.github/workflows/11-test-acceptance.yml
+++ b/.github/workflows/11-test-acceptance.yml
@@ -35,7 +35,7 @@ jobs:
           path: tailpipe-plugin-sdk
 
        # this is required, check golangci-lint-action docs
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: '1.24'
           cache: false # setup-go v4 caches by default, do not change this parameter, check golangci-lint-action doc: https://github.com/golangci/golangci-lint-action/pull/704


### PR DESCRIPTION
The org ruleset now requires all Actions pinned to a full commit SHA. `actions/setup-go` was still on the mutable `@v5` tag in `10-test-lint.yaml` and `11-test-acceptance.yml`, so every new CI run fails at 'Set up job' before building. Pins it to `40f1582b2485089dde7abd97c1529aa768e1baff` (the commit `v5` resolves to); `actions/checkout` and `golangci-lint-action` were already pinned. Workflow-only change.